### PR TITLE
Add initial support for creating labels from National Booking Service appointments

### DIFF
--- a/default-dummy-patient-list-nbs.csv
+++ b/default-dummy-patient-list-nbs.csv
@@ -1,26 +1,26 @@
 NhsNumber,FirstName,LastName,DateOfBirth,Appointment Start,RegisteredPracticeName,Address,AppointmentTypeName
-889811349,Test Patient U16 1st,Foo,29/02/2020,20/01/2021 08:30,Test General Medical Practice,"123 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-171336314,Test Patient U18 1st,Foo,31/08/2004,20/01/2021 08:40,Test General Medical Practice,"124 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-197851747,Test Patient U40 1st,Foo,14/06/1998,20/01/2021 08:50,Test General Medical Practice,"125 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-251290912,Test Patient U16 1st,Foo,21/07/2014,20/01/2021 09:00,Test General Medical Practice,"126 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-138794377,Test Patient,Foo,18/02/1934,20/01/2021 09:10,Test General Medical Practice,"127 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-684496401,Test Patient,Foo,20/03/1951,20/01/2021 09:20,Test General Medical Practice,"128 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-280602999,Test Patient,Foo,21/09/1977,20/01/2021 09:30,Test General Medical Practice,"129 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-696014651,Test Patient,Foo,02/12/1988,20/01/2021 09:40,Test General Medical Practice,"130 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
-999596593,Test Patient,Foo,30/08/1986,20/01/2021 09:50,Test General Medical Practice,"131 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-688948191,Test Patient U16 2nd,Foo,29/02/2020,20/01/2021 10:00,Test General Medical Practice,"132 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-371062034,Test Patient U40 2nd,Foo,14/06/1998,20/01/2021 10:10,Test General Medical Practice,"133 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-722063876,Test Patient,Foo,25/11/1930,20/01/2021 10:20,Test General Medical Practice,"134 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-151432123,Test Patient,Foo,07/12/1944,20/01/2021 10:30,Test General Medical Practice,"135 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-41337996,Test Patient,Foo,02/11/1978,20/01/2021 10:40,Test General Medical Practice,"136 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-90079148,Test Patient,Foo,21/07/1929,20/01/2021 10:50,Test General Medical Practice,"137 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-380315136,Test Patient,Foo,17/03/1965,20/01/2021 10:00,Test General Medical Practice,"138 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-739687046,Test Patient,Foo,25/03/1968,20/01/2021 11:10,Test General Medical Practice,"139 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-756766738,Test Patient,Foo,17/06/1958,20/01/2021 11:20,Test General Medical Practice,"140 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-900679219,Test Patient,Foo,13/12/1970,20/01/2021 11:30,Test General Medical Practice,"141 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-349888464,Test Patient,Foo,29/08/1948,20/01/2021 11:40,Test General Medical Practice,"142 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-835258980,Test Patient,Foo,30/01/1924,20/01/2021 11:50,Test General Medical Practice,"143 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-451757567,Test Patient,Foo,31/10/1942,20/01/2021 12:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
-2418409899,Test Patient Booster,Foo,15/06/1972,20/01/2021 09:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
-5001523761,Test Patient Booster,Foo,03/11/1962,20/01/2021 10:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
-9391287379,Test Patient Booster,Foo,23/02/1932,20/01/2021 10:30,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
+889811349,Test Patient U16 1st,Foo,29/02/20,20/01/2021 08:30,Test General Medical Practice,"123 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+171336314,Test Patient U18 1st,Foo,31/08/04,20/01/2021 08:40,Test General Medical Practice,"124 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+197851747,Test Patient U40 1st,Foo,14/06/98,20/01/2021 08:50,Test General Medical Practice,"125 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+251290912,Test Patient U16 1st,Foo,21/07/14,20/01/2021 09:00,Test General Medical Practice,"126 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+138794377,Test Patient,Foo,18/02/34,20/01/2021 09:10,Test General Medical Practice,"127 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+684496401,Test Patient,Foo,20/03/51,20/01/2021 09:20,Test General Medical Practice,"128 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+280602999,Test Patient,Foo,21/09/77,20/01/2021 09:30,Test General Medical Practice,"129 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+696014651,Test Patient,Foo,02/12/88,20/01/2021 09:40,Test General Medical Practice,"130 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+999596593,Test Patient,Foo,30/08/86,20/01/2021 09:50,Test General Medical Practice,"131 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+688948191,Test Patient U16 2nd,Foo,29/02/20,20/01/2021 10:00,Test General Medical Practice,"132 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+371062034,Test Patient U40 2nd,Foo,14/06/98,20/01/2021 10:10,Test General Medical Practice,"133 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+722063876,Test Patient,Foo,25/11/30,20/01/2021 10:20,Test General Medical Practice,"134 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+151432123,Test Patient,Foo,07/12/44,20/01/2021 10:30,Test General Medical Practice,"135 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+41337996,Test Patient,Foo,02/11/78,20/01/2021 10:40,Test General Medical Practice,"136 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+90079148,Test Patient,Foo,21/07/29,20/01/2021 10:50,Test General Medical Practice,"137 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+380315136,Test Patient,Foo,17/03/65,20/01/2021 10:00,Test General Medical Practice,"138 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+739687046,Test Patient,Foo,25/03/68,20/01/2021 11:10,Test General Medical Practice,"139 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+756766738,Test Patient,Foo,17/06/58,20/01/2021 11:20,Test General Medical Practice,"140 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+900679219,Test Patient,Foo,13/12/70,20/01/2021 11:30,Test General Medical Practice,"141 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+349888464,Test Patient,Foo,29/08/48,20/01/2021 11:40,Test General Medical Practice,"142 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+835258980,Test Patient,Foo,30/01/24,20/01/2021 11:50,Test General Medical Practice,"143 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+451757567,Test Patient,Foo,31/10/42,20/01/2021 12:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+2418409899,Test Patient Booster,Foo,15/06/72,20/01/2021 09:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
+5001523761,Test Patient Booster,Foo,03/11/62,20/01/2021 10:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
+9391287379,Test Patient Booster,Foo,23/02/32,20/01/2021 10:30,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster

--- a/default-dummy-patient-list-nbs.csv
+++ b/default-dummy-patient-list-nbs.csv
@@ -1,0 +1,26 @@
+NhsNumber,FirstName,LastName,DateOfBirth,Appointment Start,RegisteredPracticeName,Address,AppointmentTypeName
+889811349,Test Patient U16 1st,Foo,29/02/2020,20/01/2021 08:30,Test General Medical Practice,"123 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+171336314,Test Patient U18 1st,Foo,31/08/2004,20/01/2021 08:40,Test General Medical Practice,"124 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+197851747,Test Patient U40 1st,Foo,14/06/1998,20/01/2021 08:50,Test General Medical Practice,"125 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+251290912,Test Patient U16 1st,Foo,21/07/2014,20/01/2021 09:00,Test General Medical Practice,"126 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+138794377,Test Patient,Foo,18/02/1934,20/01/2021 09:10,Test General Medical Practice,"127 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+684496401,Test Patient,Foo,20/03/1951,20/01/2021 09:20,Test General Medical Practice,"128 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+280602999,Test Patient,Foo,21/09/1977,20/01/2021 09:30,Test General Medical Practice,"129 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+696014651,Test Patient,Foo,02/12/1988,20/01/2021 09:40,Test General Medical Practice,"130 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 1
+999596593,Test Patient,Foo,30/08/1986,20/01/2021 09:50,Test General Medical Practice,"131 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+688948191,Test Patient U16 2nd,Foo,29/02/2020,20/01/2021 10:00,Test General Medical Practice,"132 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+371062034,Test Patient U40 2nd,Foo,14/06/1998,20/01/2021 10:10,Test General Medical Practice,"133 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+722063876,Test Patient,Foo,25/11/1930,20/01/2021 10:20,Test General Medical Practice,"134 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+151432123,Test Patient,Foo,07/12/1944,20/01/2021 10:30,Test General Medical Practice,"135 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+41337996,Test Patient,Foo,02/11/1978,20/01/2021 10:40,Test General Medical Practice,"136 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+90079148,Test Patient,Foo,21/07/1929,20/01/2021 10:50,Test General Medical Practice,"137 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+380315136,Test Patient,Foo,17/03/1965,20/01/2021 10:00,Test General Medical Practice,"138 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+739687046,Test Patient,Foo,25/03/1968,20/01/2021 11:10,Test General Medical Practice,"139 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+756766738,Test Patient,Foo,17/06/1958,20/01/2021 11:20,Test General Medical Practice,"140 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+900679219,Test Patient,Foo,13/12/1970,20/01/2021 11:30,Test General Medical Practice,"141 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+349888464,Test Patient,Foo,29/08/1948,20/01/2021 11:40,Test General Medical Practice,"142 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+835258980,Test Patient,Foo,30/01/1924,20/01/2021 11:50,Test General Medical Practice,"143 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+451757567,Test Patient,Foo,31/10/1942,20/01/2021 12:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech General Dose 2
+2418409899,Test Patient Booster,Foo,15/06/1972,20/01/2021 09:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
+5001523761,Test Patient Booster,Foo,03/11/1962,20/01/2021 10:00,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster
+9391287379,Test Patient Booster,Foo,23/02/1932,20/01/2021 10:30,Test General Medical Practice,"144 Test Street, Bedford, BD12 3AD",Pfizer-BioNTech Booster

--- a/scripts/helperFunctions.js
+++ b/scripts/helperFunctions.js
@@ -57,7 +57,15 @@ function formatDate(dateString) {
 
     var year = splitDate[2];
     if (year.length == 2) {
-        year = '19' + year;
+        // NOTE(Isaac): this is a bit of a messy situation. QFlow exports DOBs
+        // with two-digit years, and so we need to pick a suitable threshold to
+        // decide which century is more likely to be correct. This seems to work
+        // pretty well on what we've seen so far.
+        if ((new Date().getFullYear().toString().substr(-2) - year) >= 0) {
+            year = '20' + year;
+        } else {
+            year = '19' + year;
+        }
     }
     //Convert text month to int
     var regExp = /[a-zA-Z]/g;

--- a/scripts/helperFunctions.js
+++ b/scripts/helperFunctions.js
@@ -103,6 +103,7 @@ function getAge(dateString) {
 //Sort list of patients alphabetically
 function sortAlphabetical(objArray) {
     function compare(a, b) {
+        // TODO(Isaac): this doesn't handle NSB's format with split name fields
         if (a.Name.toLowerCase() < b.Name.toLowerCase()) {
             return -1;
         }
@@ -120,6 +121,7 @@ function sortAlphabetical(objArray) {
 function identifyCSVKeys(CSVArray) {
     var keys = Object.keys(CSVArray[0]);
     var nhsno_key, dob_key, name_key, address_key, firstdose_type, firstdose_batch, firstdose_date;
+    var first_name_key, last_name_key, appointment_start_key;
     keys.forEach(function (key) {
         lkey = key.toLowerCase();
         if (lkey.includes('nhs')) {
@@ -144,10 +146,22 @@ function identifyCSVKeys(CSVArray) {
             if (lkey.includes('organization')) {} else
             if (lkey.includes('practice')) {} else
             if (lkey.includes('first')) {} else
+            if (lkey.includes('last')) {} else
             if (lkey.includes('sur')) {} else
+            // NOTE(Isaac): National Booking Service uses a key of AppointmentTypeName for vaccine dose. Ignore that.
+            if (lkey.includes('type')) {} else
             if (lkey.includes('pcn')) {} else {
                 name_key = key;
             }
+        }
+        if (lkey.includes('firstname')) {
+            first_name_key = key;
+        }
+        if (lkey.includes('lastname')) {
+            last_name_key = key;
+        }
+        if (lkey.includes('appointment start')) {
+            appointment_start_key = key;
         }
         if (lkey.includes('first')) {
             if (lkey.includes('date')) {
@@ -160,7 +174,6 @@ function identifyCSVKeys(CSVArray) {
                 firstdose_batch = key;
             }
         }
-
     });
 
 
@@ -169,6 +182,9 @@ function identifyCSVKeys(CSVArray) {
         name: name_key,
         nhsno: nhsno_key,
         address: address_key,
+        first_name: first_name_key,
+        last_name: last_name_key,
+        appointment_start: appointment_start_key,
         firstdose_batch: firstdose_batch,
         firstdose_date: firstdose_date,
         firstdose_type: firstdose_type

--- a/scripts/helperFunctions.js
+++ b/scripts/helperFunctions.js
@@ -33,7 +33,7 @@ function generateAgeAlertsHTML(patient) {
         patientAlertHTML = patientAlertHTML + '<p class="patient-alert">This patient is under 16</p>'
     } else if (age < 18 && vaccineType != "Pfizer-BioNTech") {
         patientAlertHTML = patientAlertHTML + '<p class="patient-alert">This patient is under 18</p>'
-    } else if (age < 40 && vaccineType == "AstraZeneca" && csvVaccineDose == "First") {
+    } else if (age < 40 && vaccineType == "AstraZeneca" && getDose(csvVaccineDose) == "First") {
         patientAlertHTML = patientAlertHTML + '<p class="patient-alert">This patient is under 40</p>'
     }
     return patientAlertHTML;

--- a/scripts/helperFunctions.js
+++ b/scripts/helperFunctions.js
@@ -207,6 +207,22 @@ function capitaliseName(str) {
     return str;
 }
 
+/// Parses a variety of dose information exported by various booking systems and returns either "First",
+/// "Second", "Booster", or "Unknown"
+// TODO(Isaac): could we extend this to handle Third Primary doses? The booking systems don't seem to handle them gracefully tho
+function getDose(csvDose) {
+    // TODO(Isaac): what does the National Booking Service give us for a Moderna or AZ dose?
+    if (csvVaccineDose == "First" || csvVaccineDose == "Pfizer-BioNTech General Dose 1") {
+        return "First";
+    } else if (csvVaccineDose == "Second" || csvVaccineDose == "Pfizer-BioNTech General Dose 2") {
+        return "Second";
+    } else if (csvVaccineDose == "Booster" || csvVaccineDose == "Pfizer-BioNTech Booster") {
+        return "Booster";
+    } else {
+        return "Unknown";
+    }
+}
+
 function generateAlert(text, elementToAppendTo, type = 'danger') {
     var alertHTML = `<div class="alert alert-` + type + `" role="alert">
         ` + text + `

--- a/scripts/template.stickers.js
+++ b/scripts/template.stickers.js
@@ -23,7 +23,7 @@ function genPatientStickersHTML() {
             if (!patient[keys['first_name']] || !patient[keys['last_name']]) {
                 throw new Error('CSV file does not contain patient names, either as single or split fields!');
             }
-            patientName = capitaliseName(patient[keys['first_name']] + ' ' + patient[keys['last_name']]);
+            patientName = capitaliseName(patient[keys['last_name']] + ', ' + patient[keys['first_name']]);
         }
 
         // NOTE(Isaac): this parses the appointment date and time from some of a number of fields, depending on the booking system:

--- a/scripts/template.stickers.js
+++ b/scripts/template.stickers.js
@@ -3,9 +3,6 @@ function genPatientStickersHTML() {
     var fullhtml = '';
 
     csvResult.forEach(function (patient, index) {
-        if (!patient[keys['name']]) {
-            return;
-        }
         if (i == 0) {
             start = `<div class="row stickers">`;
         } else {
@@ -18,35 +15,59 @@ function genPatientStickersHTML() {
             end = '';
             i++;
         }
-        sessiondate = '';
+
+        var patientName;
+        if (patient[keys['name']]) {
+            patientName = capitaliseName(patient[keys['name']]);
+        } else {
+            if (!patient[keys['first_name']] || !patient[keys['last_name']]) {
+                throw new Error('CSV file does not contain patient names, either as single or split fields!');
+            }
+            patientName = capitaliseName(patient[keys['first_name']] + ' ' + patient[keys['last_name']]);
+        }
+
+        // NOTE(Isaac): this parses the appointment date and time from some of a number of fields, depending on the booking system:
+        //     - On the National Booking Service, we split the single `Appointment Start` field by whitespace
+        //     - On AccuBook, we get separate `SessionDate` and `SessionTime` fields
+        var date = '', time = '';
         if (patient.SessionDate !== undefined) {
-            sessiondate = patient.SessionDate;
+            date = patient.SessionDate;
         }
-        sessiontime = '';
         if (patient.StartTime !== undefined) {
-            sessiontime = patient.StartTime;
+            time = patient.StartTime;
         }
+        if (patient[keys['appointment_start']] && (date === '' && time === '')) {
+            var appointment_start = patient[keys['appointment_start']].split(' ');
+            date = appointment_start[0];
+            time = appointment_start[1];
+        }
+
+        // NOTE(Isaac): we grab the expected vaccine from either the `VaccineDose` or `AppointmentTypeName` fields, depending on booking system
         csvVaccineDose = false;
         if (patient.VaccineDose !== undefined) {
             csvVaccineDose = patient.VaccineDose;
+        } else if (patient.AppointmentTypeName !== undefined) {
+            csvVaccineDose = patient.AppointmentTypeName;
         }
 
-        if (csvVaccineDose == "First") {
+        // TODO(Isaac): a helper function to match these nicely would be better
+        // TODO(Isaac): what does the National Booking Service give us for a Moderna or AZ dose?
+        if (csvVaccineDose == "First" || csvVaccineDose == "Pfizer-BioNTech General Dose 1") {
             //First Dose
-            doseHTML = generateFirstDoseHTML(sessiondate, sessiontime, batchNumber);
-        } else if (csvVaccineDose == "Second") {
+            doseHTML = generateFirstDoseHTML(date, time, batchNumber);
+        } else if (csvVaccineDose == "Second" || csvVaccineDose == "Pfizer-BioNTech General Dose 2") {
             //Second dose only
-            doseHTML = generateSecondDoseHTML(sessiondate, sessiontime, batchNumber);
-        } else if (csvVaccineDose == "Booster") {
+            doseHTML = generateSecondDoseHTML(date, time, batchNumber);
+        } else if (csvVaccineDose == "Booster" || csvVaccineDose == "Pfizer-BioNTech Booster") {
             //Second dose only
-            doseHTML = generateBoosterDoseHTML(sessiondate, sessiontime, batchNumber);
+            doseHTML = generateBoosterDoseHTML(date, time, batchNumber);
         } else {
             //No vaccine dose in CSV file, revert to unspecified
-            doseHTML = generateUnspecifiedDoseHTML(sessiondate, sessiontime, batchNumber);
+            doseHTML = generateUnspecifiedDoseHTML(date, time, batchNumber);
         }
 
         html = start + `<div class="col-sm-4">
-            <p class="patientName">` + capitaliseName(patient[keys['name']]) + `</p>
+            <p class="patientName">` + patientName + `</p>
             <table>
                 <tr>
                     <td>

--- a/scripts/template.stickers.js
+++ b/scripts/template.stickers.js
@@ -131,7 +131,7 @@ function generateUnspecifiedDoseHTML(sessiondate, sessiontime, batchNumber) {
                 <td>Batch: ` + batchNumber + `</td>
             </tr>
             <tr class="text-center">
-                <td colspan="2">First Dose | Second Dose<br>
+                <td colspan="2">First Dose | Second Dose | Booster<br>
                 <small>Circle as applicable</small></td>
             </tr>`;
 }

--- a/scripts/template.stickers.js
+++ b/scripts/template.stickers.js
@@ -50,19 +50,14 @@ function genPatientStickersHTML() {
             csvVaccineDose = patient.AppointmentTypeName;
         }
 
-        // TODO(Isaac): a helper function to match these nicely would be better
-        // TODO(Isaac): what does the National Booking Service give us for a Moderna or AZ dose?
-        if (csvVaccineDose == "First" || csvVaccineDose == "Pfizer-BioNTech General Dose 1") {
-            //First Dose
+        var dose = getDose(csvVaccineDose);
+        if (dose == "First") {
             doseHTML = generateFirstDoseHTML(date, time, batchNumber);
-        } else if (csvVaccineDose == "Second" || csvVaccineDose == "Pfizer-BioNTech General Dose 2") {
-            //Second dose only
+        } else if (dose == "Second") {
             doseHTML = generateSecondDoseHTML(date, time, batchNumber);
-        } else if (csvVaccineDose == "Booster" || csvVaccineDose == "Pfizer-BioNTech Booster") {
-            //Second dose only
+        } else if (dose == "Booster") {
             doseHTML = generateBoosterDoseHTML(date, time, batchNumber);
         } else {
-            //No vaccine dose in CSV file, revert to unspecified
             doseHTML = generateUnspecifiedDoseHTML(date, time, batchNumber);
         }
 


### PR DESCRIPTION
This extends the CSV parsing of the tool to support the output of the QFlow tool used to manage appointments booked through the National Booking Service.

I have already deployed this at the clinic I work at and it is correctly handling production data - before these modifications clinic staff were resorting to manually massaging the data with Excel to get the tool to create stickers for these appointments. Adding support to the tool directly has saved us a lot of time in the mornings. I assume at least some other sites are having this problem, and so I thought it might be helpful to submit these contributions upstream :)

This PR also adds a `Booster` option to the unspecified-dose sticker format, which can be circled as appropriate.

The code could definitely be a little cleaner and I haven't written any documentation on the new accepted format, but for initial instructions in case anyone wants to use this:
- From QFlow, go to `Tools->Calendar` and select the day you want
- Click the printer icon - a new page will open with an HTML table
- Select the entire table and copy+paste into Excel, and save as a CSV file
- Open this CSV file directly with the tool, and it should generate stickers correctly